### PR TITLE
page content toggling on v-show

### DIFF
--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -14,10 +14,10 @@
       </template>
     </PageTitle>
 
-    <Loading class="page__loading" v-if="loading" />
+    <Loading class="page__loading" v-show="loading" />
     <div
       :class="'page__content' + (contentClass ? ' ' + contentClass : '')"
-      v-else
+      v-show="!loading"
     >
       <slot name="content" />
     </div>


### PR DESCRIPTION
 event listeners and child components inside the conditional block are destroyed while conditional rendering with v-if. 
if child component wants to use the loading feature of the parent, the event will never trigger.

Please look at this doc: https://vuejs.org/v2/guide/conditional.html#v-if-vs-v-show